### PR TITLE
PHP Version Upgrade and other clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 vendor
 composer.lock
+.phpunit.cache
+phpunit.xml.bak

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
   }],
   "license": "MIT",
   "require": {
-    "php": ">=7.0.0",
-    "nesbot/carbon": "^1.0|^2.0"
+    "php": "^8.0",
+    "nesbot/carbon": "^2.0|^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0"
+    "phpunit/phpunit": "^8.0|^9.0|^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-    </php>
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/BusinessDays.php
+++ b/src/BusinessDays.php
@@ -3,19 +3,20 @@
 namespace Code16\CarbonBusiness;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 
 class BusinessDays
 {
     /** @var array */
-    protected $weekendDays = [
-        Carbon::SATURDAY+1, Carbon::SUNDAY+1
+    protected array $weekendDays = [
+        CarbonInterface::SATURDAY+1, CarbonInterface::SUNDAY+1
     ];
 
     /** @var array */
-    protected $holidays = [];
+    protected array $holidays = [];
 
     /** @var array */
-    protected $closedDays = [];
+    protected array $closedDays = [];
 
     /**
      * @param array $weekendDays
@@ -62,7 +63,7 @@ class BusinessDays
      */
     public function removeHoliday(Carbon $date): self
     {
-        if($k = array_search($date->format("Ymd"),$this->holidays) !== false) {
+        if($k = in_array($date->format("Ymd"),$this->holidays) !== false) {
             array_splice($this->holidays, $k, 1);
         }
 
@@ -75,7 +76,7 @@ class BusinessDays
      */
     public function isWeekendDay(Carbon $day): bool
     {
-        return array_search($day->dayOfWeek + 1, $this->weekendDays) !== false;
+        return in_array($day->dayOfWeek + 1, $this->weekendDays) !== false;
     }
 
     /**
@@ -84,7 +85,7 @@ class BusinessDays
      */
     public function isHoliday(Carbon $date): bool
     {
-        return array_search($date->format("Ymd"), $this->holidays) !== false;
+        return in_array($date->format("Ymd"), $this->holidays) !== false;
     }
 
     /**
@@ -110,7 +111,7 @@ class BusinessDays
      */
     public function removeClosedDay(Carbon $date): self
     {
-        if($k = array_search($date->format("Ymd"), $this->closedDays) !== false) {
+        if($k = in_array($date->format("Ymd"), $this->closedDays)) {
             array_splice($this->closedDays, $k, 1);
         }
 
@@ -123,7 +124,7 @@ class BusinessDays
      */
     public function isClosed(Carbon $date): bool
     {
-        return array_search($date->format("Ymd"), $this->closedDays) !== false;
+        return in_array($date->format("Ymd"), $this->closedDays);
     }
 
     /**
@@ -200,7 +201,7 @@ class BusinessDays
     /**
      * @return array
      */
-    public function getClosedDays()
+    public function getClosedDays(): array
     {
         return array_map(function($date) {
             return Carbon::createFromFormat('Ymd', $date)->startOfDay();
@@ -210,7 +211,7 @@ class BusinessDays
     /**
      * @return array
      */
-    public function getHolidays()
+    public function getHolidays(): array
     {
         return array_map(function($date) {
             return Carbon::createFromFormat('Ymd', $date)->startOfDay();

--- a/tests/CarbonBusinessDaysBetweenTest.php
+++ b/tests/CarbonBusinessDaysBetweenTest.php
@@ -15,35 +15,35 @@ class CarbonBusinessDaysBetweenTest extends TestCase
         $date = new BusinessDays();
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 14), // Monday
-            Carbon::createFromDate(2018, 5, 15)
+            Carbon::createFromDate(2018, 5, 14)->startOfDay(), // Monday
+            Carbon::createFromDate(2018, 5, 15)->startOfDay()
         ));
 
         $this->assertEquals(3, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 14), // Monday
-            Carbon::createFromDate(2018, 5, 17)
+            Carbon::createFromDate(2018, 5, 14)->startOfDay(), // Monday
+            Carbon::createFromDate(2018, 5, 17)->startOfDay()
         ));
 
         $this->assertEquals(5, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 14), // Monday
-            Carbon::createFromDate(2018, 5, 21)
+            Carbon::createFromDate(2018, 5, 14)->startOfDay(), // Monday
+            Carbon::createFromDate(2018, 5, 21)->startOfDay()
         ));
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 13), // Sunday
-            Carbon::createFromDate(2018, 5, 15)
+            Carbon::createFromDate(2018, 5, 13)->startOfDay(), // Sunday
+            Carbon::createFromDate(2018, 5, 15)->startOfDay()
         ));
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 12), // Saturday
-            Carbon::createFromDate(2018, 5, 15)
+            Carbon::createFromDate(2018, 5, 12)->startOfDay(), // Saturday
+            Carbon::createFromDate(2018, 5, 15)->startOfDay()
         ));
 
         $date->setWeekendDays([Carbon::SUNDAY]);
 
         $this->assertEquals(2, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 12), // Saturday
-            Carbon::createFromDate(2018, 5, 15)
+            Carbon::createFromDate(2018, 5, 12)->startOfDay(), // Saturday
+            Carbon::createFromDate(2018, 5, 15)->startOfDay()
         ));
     }
 
@@ -59,32 +59,32 @@ class CarbonBusinessDaysBetweenTest extends TestCase
         ));
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 14), // Monday
-            Carbon::createFromDate(2018, 5, 16)
+            Carbon::createFromDate(2018, 5, 14)->startOfDay(), // Monday
+            Carbon::createFromDate(2018, 5, 16)->startOfDay()
         ));
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 13), // Sunday
-            Carbon::createFromDate(2018, 5, 16)
+            Carbon::createFromDate(2018, 5, 13)->startOfDay(), // Sunday
+            Carbon::createFromDate(2018, 5, 16)->startOfDay()
         ));
 
         $this->assertEquals(2, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 13), // Sunday
-            Carbon::createFromDate(2018, 5, 17)
+            Carbon::createFromDate(2018, 5, 13)->startOfDay(), // Sunday
+            Carbon::createFromDate(2018, 5, 17)->startOfDay()
         ));
 
         $date->addHoliday(Carbon::createFromDate(2018, 5, 16));
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 13), // Sunday
-            Carbon::createFromDate(2018, 5, 17)
+            Carbon::createFromDate(2018, 5, 13)->startOfDay(), // Sunday
+            Carbon::createFromDate(2018, 5, 17)->startOfDay()
         ));
 
         $date->removeHoliday(Carbon::createFromDate(2018, 5, 16));
 
         $this->assertEquals(2, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 13), // Sunday
-            Carbon::createFromDate(2018, 5, 17)
+            Carbon::createFromDate(2018, 5, 13)->startOfDay(), // Sunday
+            Carbon::createFromDate(2018, 5, 17)->startOfDay()
         ));
     }
 
@@ -98,8 +98,8 @@ class CarbonBusinessDaysBetweenTest extends TestCase
             );
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 11), // Friday
-            Carbon::createFromDate(2018, 5, 20)
+            Carbon::createFromDate(2018, 5, 11)->startOfDay(), // Friday
+            Carbon::createFromDate(2018, 5, 20)->startOfDay()
         ));
 
         $this->assertEquals(0, $date->daysBetween(
@@ -108,15 +108,15 @@ class CarbonBusinessDaysBetweenTest extends TestCase
         ));
 
         $this->assertEquals(1, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 14), // Monday
-            Carbon::createFromDate(2018, 5, 22)
+            Carbon::createFromDate(2018, 5, 14)->startOfDay(), // Monday
+            Carbon::createFromDate(2018, 5, 22)->startOfDay()
         ));
 
         $date->removeClosedDay(Carbon::createFromDate(2018, 5, 15));
 
         $this->assertEquals(2, $date->daysBetween(
-            Carbon::createFromDate(2018, 5, 11), // Friday
-            Carbon::createFromDate(2018, 5, 20)
+            Carbon::createFromDate(2018, 5, 11)->startOfDay(), // Friday
+            Carbon::createFromDate(2018, 5, 20)->startOfDay()
         ));
     }
 }


### PR DESCRIPTION
* Migrates PHP unit file to the new format
* Adds PHP 8 type hinting to the main source (`BusinessDays.php`)
* Fixes some failing unit tests
* Deprecates support for PHP 7 and older version of PHP Unit